### PR TITLE
Generate cidrs.txt from a YAML source version

### DIFF
--- a/.github/workflows/update-cidrs-txt.yml
+++ b/.github/workflows/update-cidrs-txt.yml
@@ -1,0 +1,56 @@
+name: Update cidrs.txt
+
+on:
+  # Trigger when cidrs.yaml is modified
+  push:
+    branches: [main, master]
+    paths:
+      - 'cidrs.yaml'
+  
+  # Allow manual triggering
+  workflow_dispatch:
+  
+  # Optional: Run weekly to catch any drift
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9 AM UTC
+
+jobs:
+  update-cidrs:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write  # Required to push changes back to repo
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      
+      - name: Make script executable
+        run: chmod +x generate-cidrs.sh
+      
+      - name: Generate cidrs.txt
+        run: ./generate_cidrs_txt.sh cidrs.yaml cidrs.txt
+      
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code cidrs.txt || echo "changed=true" >> $GITHUB_OUTPUT
+      
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add cidrs.txt
+          git commit -m "Auto-update cidrs.txt from cidrs.yaml"
+          git push
+      
+      - name: No changes detected
+        if: steps.git-check.outputs.changed != 'true'
+        run: echo "No changes detected in cidrs.txt"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LAA Shared IP Allow list
-The list is intended to be pulled into applications for adding allow lists to IP-restricted areas. This should not be seen as a primary level of protection.
+The list is for use by LAA services that need their access restricted to an allow-list of internal devices. IP allow-listing should not be seen as a primary level of protection.
 
 ## Usage
 The list can be pulled from this URL: https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt
@@ -11,7 +11,12 @@ This can be done using your Helm chart, bash scripts, pipeline configuration or 
 Using bash script combined with Helm Chart: ministryofjustice/cla_public#1276
 
 ## Maintenance
-Please update the list without any spaces and comments. Use one IP range per line.
+Please update the source list in cidrs.yaml, and then run:
+```
+./generate_cidrs_txt.sh
+```
+
+cidrs.txt will be generated with one IP range per line, and without any spaces and comments.
 
 
 ### Future development

--- a/cidrs.yaml
+++ b/cidrs.yaml
@@ -1,0 +1,21 @@
+# MOJ / LAA Egress IP Ranges
+# This file is the source for LAA IP allowlists
+user_devices:
+  # MoJO Production user egress
+  - 51.149.249.0/29
+  # ARK user egress
+  - 194.33.249.0/29
+  - 51.149.249.32/29
+  - 194.33.248.0/29
+  # Azure Virtual Desktop user egress
+  - 20.49.214.199/32
+  - 20.49.214.228/32
+  - 20.26.11.71/32
+  - 20.26.11.108/32
+  # Prisma VPN user egress
+  - 128.77.75.64/26
+  # Alpha VPN user egress
+  - 18.169.147.172/32
+  - 35.176.93.186/32
+  - 18.130.148.126/32
+  - 35.176.148.126/32

--- a/generate_cidrs_txt.sh
+++ b/generate_cidrs_txt.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Generate cidrs.txt from cidrs.yaml
+# This script converts a YAML file with grouped CIDRs into a simple newline-separated list
+
+set -euo pipefail
+
+YAML_FILE="${1:-cidrs.yaml}"
+OUTPUT_FILE="${2:-cidrs.txt}"
+
+# Check if input file exists
+if [[ ! -f "$YAML_FILE" ]]; then
+    echo "Error: YAML file '$YAML_FILE' not found" >&2
+    exit 1
+fi
+
+# Check if yq is installed
+if ! command -v yq &> /dev/null; then
+    echo "Error: yq is required but not installed" >&2
+    echo "Install with: brew install yq" >&2
+    exit 1
+fi
+
+# Generate the cidrs.txt file
+echo "Generating $OUTPUT_FILE from $YAML_FILE..."
+
+# Extract all CIDRs from the user_devices array
+yq eval '.user_devices[]' "$YAML_FILE" > "$OUTPUT_FILE"
+
+echo "Successfully generated $OUTPUT_FILE"
+echo "Contents:"
+cat "$OUTPUT_FILE"


### PR DESCRIPTION
Because the YAML source can include comments about what the CIDRs actualy are, which is useful to understand what is and isn't included. Couldn't put comments in cidrs.txt because that is in use by repos already, and comments would disrupt those clients. YAML is also helpful when we want different allowlists for different apps, as seen in https://github.com/ministryofjustice/hmpps-ip-allowlists/tree/main